### PR TITLE
Add support for minify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ In your `webpack.mix.js` just use `mix.buildHtml()`. If you want to use the defa
 mix.buildHtml({
     htmlRoot: './src/index.html', // Your html root file
     output: 'dist', // The html output folder
-    partialRoot: './src/partials',    // OPTIONAL: default partial path
-    minify: true
+    partialRoot: './src/partials',    // default partial path
+    minify: {
+        removeComments: true
+    }
 });
 ```
 
@@ -28,7 +30,7 @@ Name | Type | Default | Description
 `partialRoot` | `{String}` | `'./src/partials'` |  Default path for html partial files
 `output` | `{String}` | `'dist'` |  The folder where your output files should be saved
 `inject`* | `{Boolean}` | `false` |  Whether or not your css and javascript files should automatically included in your output
-`minify` | `{Boolean}` | `true` if `mode` is `'production'`, otherwise `false` |  To disable minification during production mode set the minify option to `false`.
+`minify` | `{Object}` | see [minify](#Minification) section |  An object with minify-options. See [minify](#Minification) for more information.
 
 **\*KNOWN ISSUE**:
 Due to an [issue in the laravel-mix core](https://github.com/JeffreyWay/laravel-mix/issues/1717) the `src` of script tag will have a leading double slash, which kills the functionality of it. Linking the css file yet works fine. I included the option as an experimental feature and I am working on a workaround to fix this until the development of mix will continue.
@@ -65,4 +67,22 @@ When you run mix it will automatically generate `/dist/index.html` like this:
 <p>
     I am a wonderful and useless text!
 </p>
+```
+
+### Minification
+
+You have the possibility to minify your html code according to the [kangax/html-minifier](https://github.com/kangax/html-minifier#options-quick-reference) package. Just add any option you need, it will be passed to the minifier. If you want to remove minification, just set its value to `false`;
+
+#### Default value
+
+The default value of this field is the following object:
+
+```
+{
+    removeComments: true,
+    removeRedundantAttributes: true,
+    removeScriptTypeAttributes: true,
+    removeStyleLinkTypeAttributes: true,
+    useShortDoctype: true
+}
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ In your `webpack.mix.js` just use `mix.buildHtml()`. If you want to use the defa
 mix.buildHtml({
     htmlRoot: './src/index.html', // Your html root file
     output: './out/index.html', // The html output file
-    partialRoot: './src/partials'    // OPTIONAL: default partial path
+    partialRoot: './src/partials',    // OPTIONAL: default partial path
+    minify: true
 });
 ```
 
@@ -27,6 +28,7 @@ Name | Type | Default | Description
 `partialRoot` | `{String}` | `'./src/partials'` |  Default path for html partial files
 `output` | `{String}` | `'index.html'` |  How your output html file should be named
 `inject`* | `{Boolean}` | `false` |  Whether or not your css and javascript files should automatically included in your output
+`minify` | `{Boolean}` | `true` if `mode` is `'production'`, otherwise `false` |  To disable minification during production mode set the minify option to `false`.
 
 **\*KNOWN ISSUE**:
 Due to an [issue in the laravel-mix core](https://github.com/JeffreyWay/laravel-mix/issues/1717) the `src` of script tag will have a leading double slash, which kills the functionality of it. Linking the css file yet works fine. I included the option as an experimental feature and I am working on a workaround to fix this until the development of mix will continue.

--- a/mix-html-builder.js
+++ b/mix-html-builder.js
@@ -24,8 +24,14 @@ class HtmlBuilder {
             this.partialRoot = input.partialRoot;
         }
 
-        if (!input.minify) {
-            this.minify = 'auto'
+        if (typeof input.minify === 'undefined') {
+            this.minify = {
+                removeComments: true,
+                removeRedundantAttributes: true,
+                removeScriptTypeAttributes: true,
+                removeStyleLinkTypeAttributes: true,
+                useShortDoctype: true
+            };
         } else {
             this.minify = input.minify;
         }

--- a/mix-html-builder.js
+++ b/mix-html-builder.js
@@ -23,6 +23,8 @@ class HtmlBuilder {
         }
 
         this.inject = input.inject;
+        
+        this.minify = input.minify;
     }
 
     dependencies() {

--- a/mix-html-builder.js
+++ b/mix-html-builder.js
@@ -22,9 +22,14 @@ class HtmlBuilder {
             this.partialRoot = input.partialRoot;
         }
 
+        if (!input.minify) {
+            this.minify = 'auto'
+        } else {
+            this.minify = input.minify;
+        }
+
         this.inject = input.inject;
-        
-        this.minify = input.minify;
+ 
     }
 
     dependencies() {
@@ -57,6 +62,7 @@ class HtmlBuilder {
             filename: this.output,
             template: this.htmlRoot,
             inject: this.inject,
+            minify: this.minify
         });
     }
 }


### PR DESCRIPTION
Hey @philicevic! I needed to remove collapsed whitespace in production and it seemed like there was no way to pass the `minify` option to the `html-webpack-plugin`. I've added a `minify` option that defaults to `auto`, which you can set to `false` to disable minification for all environments.

However, it doesn't work and there appears to be a related open issue here: https://github.com/jantimon/html-webpack-plugin/issues/1094

Thoughts?

