### PR TITLE
Added the ability to pass "output" value as empty string

### DIFF
--- a/mix-html-builder.js
+++ b/mix-html-builder.js
@@ -19,6 +19,12 @@ class HtmlBuilder {
             this.output = input.output;
         }
 
+        // Add trailing slash only if the value is not an empty string
+        // to use the value specified by the "setPublicPath" function
+        if(this.output.length > 0) {
+            this.output += this.output.endsWith('/') ? '' : '/';
+        }
+
         let partialRoot;
         if (typeof input.partialRoot === 'undefined') {
             partialRoot = './src/partials';
@@ -134,7 +140,7 @@ class HtmlBuilder {
             let filename = path.relative(htmlRootDir, file);
             Plugins.push(
                 new HtmlWebpackPlugin({
-                    filename: this.output + '/' + filename,
+                    filename: this.output + filename,
                     template: file,
                     inject: this.inject,
                     minify: this.minify,


### PR DESCRIPTION
Previously, this configuration returned errors because it tried to create a file in the root folder because of the trailing slash.

```
...
mix.html({
  htmlRoot: './src/views/pages/**/*.html',
  output: '',
  partialRoot: './src/views/partials',
  layoutRoot: './src/views/layouts',
  minify: {
    removeComments: true
  }
});
mix.setPublicPath('dist');
...
```
after changing the files will be created in the "dist" folder without any conflict with function `mix.setPublicPath`.

Working examples below:
```
mix.html(); // save to 'dist/'
// or
mix.html({
    output: 'html', // save to 'html/' 
});
// or
mix.setPublicPath('dist');
mix.html(); // save to 'dist/dist/'
// or
mix.setPublicPath('dist');
mix.html({
    output: 'html', // save to 'dist/html/'
});
// or
mix.setPublicPath('dist');
mix.html({
    output: '', // save to 'dist/'
});
```