### PR TITLE
Update version constraints for mix-6

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "posthtml-loader": "^2.0.1"
   },
   "peerDependencies": {
-    "laravel-mix": ">=3.0.0 <=5.0.0"
+    "laravel-mix": ">=3.0.0 <=6.0.0"
   },
   "devDependencies": {
     "filename-regex": "^2.0.1",


### PR DESCRIPTION
It seems that this works fine for mix-6 after lifting the constraints, and the tests included run fine as well. This fixes #24.